### PR TITLE
Documentation fix for "remove oldest items" example

### DIFF
--- a/lib/XML/RSS.pm
+++ b/lib/XML/RSS.pm
@@ -1648,7 +1648,7 @@ XML::RSS - creates and updates RSS files
 
  while (@{$rss->{'items'}} >= 15)
  {
-     pop (@{ $rss->{'items'} });
+     shift (@{ $rss->{'items'} });
  }
 
  $rss->add_item(title => "MpegTV Player (mtv) 1.0.9.7",


### PR DESCRIPTION
The oldest items should be at the beginning of the items array;
therefore, `shift()` should be used to remove them, as opposed to `pop()`.
